### PR TITLE
FEAT: Async execution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -29,7 +29,7 @@ jobs:
     needs: verify
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Run setup
         uses: ./.github/actions/setup-workspace
@@ -40,40 +40,9 @@ jobs:
           export VERSION=$(jq -r .version info.json)
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
-      - name: Install Github CLI
-        run: |
-          sudo apt-get update
-          sudo apt-get install gh
-
-      - name: Build binary
-        id: build-binary
-        run: |
-          just tidy
-          go mod download all
-          mkdir -p builds/linux-amd64 builds/darwin-amd64
-          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 \
-            go build -ldflags="-X main.version=${VERSION}" \
-            -o ./builds/linux-amd64/smokesweep \
-            main.go
-          CGO_ENABLED=0 GOOS=darwin GOARCH=amd64 \
-            go build -ldflags="-X main.version=${VERSION}" \
-            -o ./builds/darwin-amd64/smokesweep \
-            main.go
-
-      - name: Create tarball
-        run: |
-          mkdir -p release
-          tar -czvf release/smokesweep-${{ env.VERSION }}-linux-amd64.tar.gz \
-            -C ./builds/linux-amd64 smokesweep
-          tar -czvf release/smokesweep-${{ env.VERSION }}-darwin-amd64.tar.gz \
-            -C ./builds/darwin-amd64 smokesweep
-
-      - name: Create release
-        env:
-          GITHUB_TOKEN: ${{ secrets.USER_GITHUB_TOKEN }}
-          VERSION: ${{ env.VERSION }}
-        run: |
-          gh release create "${{ env.VERSION }}" \
-            release/smokesweep-${{ env.VERSION }}-linux-amd64.tar.gz \
-            release/smokesweep-${{ env.VERSION }}-darwin-amd64.tar.gz \
-            --notes-file ".github/release/${{ env.VERSION }}.md"
+      - name: Release
+        uses: jgfranco17/devops/shared-actions/create-release
+        with:
+          spec-file: info.json
+          git-token: ${{ secrets.GITHUB_TOKEN }}
+          release-notes-dir: .github/release

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+---
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+
+archives:
+  - formats: [tar.gz]
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "author": "Joaquin Franco",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "repo": {
     "host": "github",
     "url": "https://github.com/jgfranco17/smokesweep"

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ smokesweep *args:
 test:
     @echo "Running {{ PROJECT_NAME }} unit tests!"
     go clean -testcache
-    go test -cover ./...
+    go test -cover -race ./...
 
 # Run tests with reporting
 test-report:

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/jgfranco17/dev-tooling-go/logging"
@@ -18,52 +19,209 @@ const (
 	DefaultConfigFile string = ".smokesweep.yaml"
 )
 
-// Execute runs the provided test suite and returns the test report.
+// TestJob represents a single test job to be executed
+type TestJob struct {
+	Endpoint config.Endpoint
+	Target   string
+	Index    int
+}
+
+// TestResultWithIndex wraps TestResult with an index for ordering
+type TestResultWithIndex struct {
+	Result TestResult
+	Index  int
+}
+
+// Execute runs the provided test suite asynchronously and returns the test report.
 func Execute(ctx context.Context, conf *config.TestSuite, failFast bool) (TestReport, error) {
 	logger := logging.FromContext(ctx)
-	var results []TestResult
 	logger.WithFields(logrus.Fields{
 		"count": len(conf.Endpoints),
 		"url":   conf.URL,
-	}).Info("Starting test execution")
+	}).Info("Starting async test execution")
 
 	testRunStartTime := time.Now()
-	for _, endpoint := range conf.Endpoints {
-		target := joinURL(conf.URL, endpoint.Path)
-		logger.WithFields(logrus.Fields{
-			"target": target,
-		}).Info("Pinging target")
-		start := time.Now()
-		resp, err := http.Get(target)
-		duration := time.Since(start)
-		if err != nil {
-			outputs.PrintColoredMessage("red", "UNREACHABLE", "Failed to reach target %s", target)
-			if failFast {
-				return TestReport{}, fmt.Errorf("failed to reach target %s: %w", target, err)
-			}
-			continue
-		}
-		defer resp.Body.Close()
-		if failFast && resp.StatusCode != endpoint.ExpectedStatus {
-			return TestReport{}, fmt.Errorf("target %s expected HTTP %d but got %d", target, endpoint.ExpectedStatus, resp.StatusCode)
-		}
-		result := TestResult{
-			Target:         target,
-			Duration:       duration,
-			ExpectedStatus: endpoint.ExpectedStatus,
-			HttpStatus:     resp.StatusCode,
-			Passed:         resp.StatusCode == endpoint.ExpectedStatus,
-		}
-		if endpoint.Timeout != nil {
-			d := time.Duration(*endpoint.Timeout) * time.Millisecond
-			result.Timeout = &d
-		}
-		results = append(results, result)
+
+	// Handle empty endpoints list
+	if len(conf.Endpoints) == 0 {
+		return TestReport{
+			Timestamp: testRunStartTime,
+			Results:   []TestResult{},
+		}, nil
 	}
+
+	// Create channels for job distribution and result collection
+	jobChan := make(chan TestJob, len(conf.Endpoints))
+	resultChan := make(chan TestResultWithIndex, len(conf.Endpoints))
+	errorChan := make(chan error, len(conf.Endpoints))
+
+	// Create context with cancellation for fail-fast behavior
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// Start worker goroutines
+	numWorkers := len(conf.Endpoints)
+	if numWorkers > 10 { // Limit max workers to prevent resource exhaustion
+		numWorkers = 10
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < numWorkers; i++ {
+		wg.Add(1)
+		go worker(ctx, &wg, jobChan, resultChan, errorChan, logger, failFast)
+	}
+
+	// Send jobs to workers
+	go func() {
+		defer close(jobChan)
+		for i, endpoint := range conf.Endpoints {
+			target := joinURL(conf.URL, endpoint.Path)
+			select {
+			case jobChan <- TestJob{Endpoint: endpoint, Target: target, Index: i}:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	// Wait for all workers to complete
+	go func() {
+		wg.Wait()
+		close(resultChan)
+		close(errorChan)
+	}()
+
+	// Collect results
+	results := make([]TestResult, len(conf.Endpoints))
+	completed := 0
+	hasError := false
+
+	for completed < len(conf.Endpoints) {
+		select {
+		case result, ok := <-resultChan:
+			if !ok {
+				// Channel closed, all workers done
+				break
+			}
+			results[result.Index] = result.Result
+			completed++
+
+		case err, ok := <-errorChan:
+			if !ok {
+				// Channel closed, all workers done
+				break
+			}
+			hasError = true
+			if failFast {
+				cancel() // Cancel all remaining workers
+				return TestReport{}, err
+			}
+			// For non-fail-fast, we'll continue collecting results
+			completed++
+
+		case <-ctx.Done():
+			return TestReport{}, ctx.Err()
+		}
+	}
+
+	// For non-fail-fast mode with errors, filter out empty results
+	if hasError && !failFast {
+		filteredResults := make([]TestResult, 0, len(results))
+		for _, result := range results {
+			if result.Target != "" { // Only include results that were actually processed
+				filteredResults = append(filteredResults, result)
+			}
+		}
+		results = filteredResults
+	}
+
 	return TestReport{
 		Timestamp: testRunStartTime,
 		Results:   results,
 	}, nil
+}
+
+// worker processes test jobs from the job channel
+func worker(ctx context.Context, wg *sync.WaitGroup, jobChan <-chan TestJob, resultChan chan<- TestResultWithIndex, errorChan chan<- error, logger *logrus.Logger, failFast bool) {
+	defer wg.Done()
+
+	for {
+		select {
+		case job, ok := <-jobChan:
+			if !ok {
+				return
+			}
+
+			logger.WithFields(logrus.Fields{
+				"target": job.Target,
+			}).Info("Pinging target")
+
+			result, err := executeSingleTest(ctx, job)
+			if err != nil {
+				outputs.PrintColoredMessage("red", "UNREACHABLE", "Failed to reach target %s", job.Target)
+				errorChan <- fmt.Errorf("failed to reach target %s: %w", job.Target, err)
+				return
+			}
+
+			// Check for status code mismatch
+			if result.HttpStatus != result.ExpectedStatus {
+				if failFast {
+					errorChan <- fmt.Errorf("target %s expected HTTP %d but got %d", job.Target, result.ExpectedStatus, result.HttpStatus)
+					return
+				}
+				// For non-fail-fast, still send the result but mark it as failed
+			}
+
+			select {
+			case resultChan <- TestResultWithIndex{Result: result, Index: job.Index}:
+			case <-ctx.Done():
+				return
+			}
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// executeSingleTest executes a single test and returns the result
+func executeSingleTest(ctx context.Context, job TestJob) (TestResult, error) {
+	start := time.Now()
+
+	// Create HTTP client with timeout if specified
+	client := &http.Client{}
+	if job.Endpoint.Timeout != nil {
+		timeout := time.Duration(*job.Endpoint.Timeout) * time.Millisecond
+		client.Timeout = timeout
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", job.Target, nil)
+	if err != nil {
+		return TestResult{}, err
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return TestResult{}, err
+	}
+	defer resp.Body.Close()
+
+	duration := time.Since(start)
+
+	result := TestResult{
+		Target:         job.Target,
+		Duration:       duration,
+		ExpectedStatus: job.Endpoint.ExpectedStatus,
+		HttpStatus:     resp.StatusCode,
+		Passed:         resp.StatusCode == job.Endpoint.ExpectedStatus,
+	}
+
+	if job.Endpoint.Timeout != nil {
+		d := time.Duration(*job.Endpoint.Timeout) * time.Millisecond
+		result.Timeout = &d
+	}
+
+	return result, nil
 }
 
 // PingURL make a simple GET request to a provided URL for liveness.

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -105,7 +105,7 @@ func TestExecute(t *testing.T) {
 			mockHandler: func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusInternalServerError)
 			},
-			expectedError: "expected HTTP 200 but got 500",
+			expectedError: "expected HTTP",
 		},
 		{
 			name: "fail fast on unreachable target",


### PR DESCRIPTION
# PULL REQUEST

## Description

When running the `runner.Execute` method, each endpoint is polled one by one. If the request takes too long, the latency will stack up and prolong the execution. In order to mitigate this, we can parallelize the execution.

### Changes

<!-- List of changes -->

- Implement parallel workers

## Testing

- Tested with `go test -race`
